### PR TITLE
Add CSS token system with migration scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# Copilot Style Rules
+
+- All new CSS must use variables defined in `src/styles/variables.css`.
+- Import `src/styles/variables.css` in any global style entry if not already present.
+- Prefer `var(--spacing-X)` for spacing multiples of 4px.
+- Colors, typography values, radii and shadows should reference the corresponding CSS variables.

--- a/CSS_TOKENS_GUIDE.md
+++ b/CSS_TOKENS_GUIDE.md
@@ -1,0 +1,44 @@
+# CSS Tokens Guide
+
+Este proyecto utiliza un sistema de variables CSS centralizado. Las variables se definen en `src/styles/variables.css` y se basan en `src/styles/tokens.ts`.
+
+## Ejemplos de Uso
+
+```css
+.button {
+  background: var(--color-primary);
+  padding: var(--spacing-3) var(--spacing-5);
+  border-radius: var(--radius-md);
+}
+```
+
+## Tabla de Conversión
+
+| Valor original | Token |
+| -------------- | ----- |
+| `#1476FF` | `var(--color-primary)` |
+| `#0F64DB` | `var(--color-primary-hover)` |
+| `#FF3B30` | `var(--color-error)` |
+| `#FF9500` | `var(--color-warning)` |
+| `#34C759` | `var(--color-success)` |
+| `#5AC8FA` | `var(--color-info)` |
+| `#0A0A0A` | `var(--color-text-high)` |
+| `#545454` | `var(--color-text-medium)` |
+| `#8E8E93` | `var(--color-text-low)` |
+| `#FFFFFF` | `var(--color-surface-01)` |
+| `#F6F7F9` | `var(--color-surface-02)` |
+| `#E5E5EA` | `var(--color-stroke)` |
+| `4px` | `var(--spacing-1)` |
+| `8px` | `var(--spacing-2)` |
+| `12px` | `var(--spacing-3)` |
+| `16px` | `var(--spacing-4)` |
+| `20px` | `var(--spacing-5)` |
+| `24px` | `var(--spacing-6)` |
+| `6px` | `var(--radius-sm)` |
+| `12px` | `var(--radius-md)` |
+| `20px` | `var(--radius-lg)` |
+| `999px` | `var(--radius-pill)` |
+| `0px 2px 6px rgba(0,0,0,0.06)` | `var(--shadow-card)` |
+| `0px 4px 12px rgba(0,0,0,0.08)` | `var(--shadow-elevated)` |
+
+Al migrar estilos existentes, reemplaza los valores de la izquierda por los tokens correspondientes de la derecha, excepto en los casos explícitamente excluidos como alturas de inputs (44px) o breakpoints (768px).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "tokens:audit": "node scripts/audit-css.cjs",
+    "tokens:migrate": "node scripts/migrate-css-tokens.cjs",
+    "tokens:validate": "node scripts/validate-css-tokens.cjs"
   },
   "dependencies": {
     "lucide-react": "^0.520.0",

--- a/scripts/audit-css.cjs
+++ b/scripts/audit-css.cjs
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .flatMap(entry => {
+      const res = path.join(dir, entry.name);
+      return entry.isDirectory() ? walk(res) : res;
+    });
+}
+
+const files = walk(path.join(__dirname, '../src'))
+  .filter(f => f.endsWith('.module.css'));
+
+const colors = new Set();
+const sizes = new Set();
+const radii = new Set();
+const shadows = new Set();
+
+files.forEach(file => {
+  const content = fs.readFileSync(file, 'utf8');
+  for (const m of content.matchAll(/#[0-9a-fA-F]{3,6}\b|rgba?\([^\)]+\)/g)) {
+    colors.add(m[0]);
+  }
+  for (const m of content.matchAll(/\b\d+px\b/g)) {
+    const value = m[0];
+    if (/radius|border-radius/.test(content.slice(Math.max(0, m.index - 20), m.index + 20))) {
+      radii.add(value);
+    } else if (/box-shadow/.test(content.slice(Math.max(0, m.index - 20), m.index + 20))) {
+      shadows.add(value);
+    } else {
+      sizes.add(value);
+    }
+  }
+});
+
+console.log('CSS Audit Results');
+console.log('Colors:', Array.from(colors).join(', '));
+console.log('Sizes:', Array.from(sizes).join(', '));
+console.log('Radii:', Array.from(radii).join(', '));
+console.log('Shadows:', Array.from(shadows).join(', '));

--- a/scripts/migrate-css-tokens.cjs
+++ b/scripts/migrate-css-tokens.cjs
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+const tokenMap = {
+  '#1476FF': 'var(--color-primary)',
+  '#0F64DB': 'var(--color-primary-hover)',
+  '#FF3B30': 'var(--color-error)',
+  '#FF9500': 'var(--color-warning)',
+  '#34C759': 'var(--color-success)',
+  '#5AC8FA': 'var(--color-info)',
+  '#0A0A0A': 'var(--color-text-high)',
+  '#545454': 'var(--color-text-medium)',
+  '#8E8E93': 'var(--color-text-low)',
+  '#FFFFFF': 'var(--color-surface-01)',
+  '#F6F7F9': 'var(--color-surface-02)',
+  '#E5E5EA': 'var(--color-stroke)',
+  'rgba(0,0,0,0.25)': 'var(--color-overlay)'
+};
+
+const spacingMap = {
+  '4px': 'var(--spacing-1)',
+  '8px': 'var(--spacing-2)',
+  '12px': 'var(--spacing-3)',
+  '16px': 'var(--spacing-4)',
+  '20px': 'var(--spacing-5)',
+  '24px': 'var(--spacing-6)'
+};
+
+const radiusMap = {
+  '6px': 'var(--radius-sm)',
+  '12px': 'var(--radius-md)',
+  '20px': 'var(--radius-lg)',
+  '999px': 'var(--radius-pill)'
+};
+
+const shadowMap = {
+  '0px 2px 6px rgba(0,0,0,0.06)': 'var(--shadow-card)',
+  '0px 4px 12px rgba(0,0,0,0.08)': 'var(--shadow-elevated)'
+};
+
+const ignoreValues = new Set(['44px', '768px']);
+
+function escapeReg(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceRadius(content) {
+  for (const [val, variable] of Object.entries(radiusMap)) {
+    const reg = new RegExp(`(border-radius\\s*:\\s*)${escapeReg(val)}`, 'g');
+    content = content.replace(reg, `$1${variable}`);
+  }
+  return content;
+}
+
+function replaceAll(content, map) {
+  const entries = Object.entries(map).sort((a,b) => b[0].length - a[0].length);
+  for (const [val, variable] of entries) {
+    if (ignoreValues.has(val)) continue;
+    const reg = new RegExp(`(?<![\\d])${escapeReg(val)}(?![\\w])`, 'g');
+    content = content.replace(reg, variable);
+  }
+  return content;
+}
+
+function processFile(file) {
+  let css = fs.readFileSync(file, 'utf8');
+  css = replaceAll(css, tokenMap);
+  css = replaceRadius(css);
+  css = replaceAll(css, spacingMap);
+  css = replaceAll(css, shadowMap);
+  fs.writeFileSync(file, css);
+}
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .flatMap(ent => {
+      const res = path.join(dir, ent.name);
+      return ent.isDirectory() ? walk(res) : res;
+    });
+}
+
+const files = walk(path.join(root, 'src')).filter(f => f.endsWith('.css') && !f.endsWith('variables.css'));
+files.forEach(processFile);
+console.log('Migrated', files.length, 'CSS files');

--- a/scripts/validate-css-tokens.cjs
+++ b/scripts/validate-css-tokens.cjs
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const ignoreValues = new Set(['44px', '768px']);
+
+const valueRegex = /#[0-9a-fA-F]{3,6}\b|rgba?\([^\)]+\)|\b\d+px\b/gi;
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .flatMap(ent => {
+      const res = path.join(dir, ent.name);
+      return ent.isDirectory() ? walk(res) : res;
+    });
+}
+
+const files = walk(path.join(root, 'src')).filter(f => f.endsWith('.css') && !f.endsWith('variables.css'));
+
+let total = 0;
+let remaining = 0;
+
+files.forEach(file => {
+  const content = fs.readFileSync(file, 'utf8');
+  const matches = content.match(valueRegex) || [];
+  matches.forEach(v => {
+    total++;
+    if (v.startsWith('var(') || ignoreValues.has(v)) return;
+    remaining++;
+    console.log(file + ': ' + v);
+  });
+});
+
+console.log(`Remaining hardcoded values: ${remaining} of ${total}`);

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,7 +1,7 @@
 /* Estilos para la aplicación principal */
 .app {
   min-height: 100vh;
-  background-color: #F6F7F9;
+  background-color: var(--color-surface-02);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
 }
@@ -19,27 +19,27 @@
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .content {
-  background-color: #FFFFFF;
-  border-radius: 20px;
+  background-color: var(--color-surface-01);
+  border-radius: var(--spacing-5);
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.06);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .fab {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
+  bottom: var(--spacing-6);
+  right: var(--spacing-6);
   width: 56px;
   height: 56px;
-  background-color: #1476FF;
-  color: #FFFFFF;
+  background-color: var(--color-primary);
+  color: var(--color-surface-01);
   border: none;
   border-radius: 50%;
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: 0px var(--spacing-1) var(--spacing-3) rgba(0, 0, 0, 0.08);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -50,7 +50,7 @@
 
 .fab:hover {
   transform: scale(1.1);
-  box-shadow: 0px 6px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: 0px 6px var(--spacing-4) rgba(0, 0, 0, 0.12);
 }
 
 .fab:active {
@@ -63,16 +63,16 @@
   }
   
   .container {
-    padding: 16px;
+    padding: var(--spacing-4);
     padding-top: 80px; /* Espacio para el botón de menú */
   }
   
   .content {
-    padding: 20px;
+    padding: var(--spacing-5);
   }
   
   .fab {
-    bottom: 16px;
-    right: 16px;
+    bottom: var(--spacing-4);
+    right: var(--spacing-4);
   }
 }

--- a/src/components/Contact/ContactList.module.css
+++ b/src/components/Contact/ContactList.module.css
@@ -3,12 +3,12 @@
 .avatar {
   width: 48px;
   height: 48px;
-  background-color: #1476FF;
+  background-color: var(--color-primary);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #FFFFFF;
+  color: var(--color-surface-01);
   font-weight: 600;
   font-size: 18px;
   font-family: system-ui, -apple-system, sans-serif;
@@ -19,14 +19,14 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   min-width: 0;
 }
 
 .name {
   font-size: 17px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
   margin: 0;
   white-space: nowrap;
@@ -42,7 +42,7 @@
 
 .contact-detail {
   font-size: 13px;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
@@ -54,15 +54,15 @@
 
 .empty-state {
   text-align: center;
-  padding: 48px 24px;
-  color: #8E8E93;
+  padding: 48px var(--spacing-6);
+  color: var(--color-text-low);
 }
 
 .empty-state h3 {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 600;
-  color: #545454;
-  margin: 0 0 8px 0;
+  color: var(--color-text-medium);
+  margin: 0 0 var(--spacing-2) 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
@@ -75,17 +75,17 @@
 .list-container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 @media (max-width: 640px) {
   .avatar {
     width: 40px;
     height: 40px;
-    font-size: 16px;
+    font-size: var(--spacing-4);
   }
   
   .contact-detail {
-    font-size: 12px;
+    font-size: var(--spacing-3);
   }
 }

--- a/src/components/Product/ProductForm.module.css
+++ b/src/components/Product/ProductForm.module.css
@@ -8,11 +8,11 @@
 .profit-info {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
   background-color: #F0F9FF;
   border: 1px solid #0EA5E9;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 13px;
   color: #0369A1;
   font-family: system-ui, -apple-system, sans-serif;

--- a/src/components/Product/ProductList.module.css
+++ b/src/components/Product/ProductList.module.css
@@ -4,12 +4,12 @@
 .avatar {
   width: 48px;
   height: 48px;
-  background-color: #1476FF;
+  background-color: var(--color-primary);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #FFFFFF;
+  color: var(--color-surface-01);
   font-weight: 600;
   font-size: 18px;
   font-family: system-ui, -apple-system, sans-serif;
@@ -20,14 +20,14 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   min-width: 0;
 }
 
 .name {
   font-size: 17px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
   margin: 0;
   white-space: nowrap;
@@ -43,7 +43,7 @@
 
 .contact-detail {
   font-size: 13px;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
@@ -55,15 +55,15 @@
 
 .empty-state {
   text-align: center;
-  padding: 48px 24px;
-  color: #8E8E93;
+  padding: 48px var(--spacing-6);
+  color: var(--color-text-low);
 }
 
 .empty-state h3 {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 600;
-  color: #545454;
-  margin: 0 0 8px 0;
+  color: var(--color-text-medium);
+  margin: 0 0 var(--spacing-2) 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
@@ -76,17 +76,17 @@
 .list-container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 @media (max-width: 640px) {
   .avatar {
     width: 40px;
     height: 40px;
-    font-size: 16px;
+    font-size: var(--spacing-4);
   }
   
   .contact-detail {
-    font-size: 12px;
+    font-size: var(--spacing-3);
   }
 }

--- a/src/components/Purchase/PurchaseForm.module.css
+++ b/src/components/Purchase/PurchaseForm.module.css
@@ -3,17 +3,17 @@
 .items-container {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .item-row {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: flex-start;
-  padding: 16px;
-  background-color: #FFFFFF;
-  border: 1px solid #E5E5EA;
-  border-radius: 8px;
+  padding: var(--spacing-4);
+  background-color: var(--color-surface-01);
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--spacing-2);
 }
 
 .item-select {
@@ -35,25 +35,25 @@
   min-width: 120px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   font-size: 15px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
-  background-color: #F6F7F9;
-  padding: 12px 16px;
-  border-radius: 6px;
-  border: 1px solid #E5E5EA;
+  background-color: var(--color-surface-02);
+  padding: var(--spacing-3) var(--spacing-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-stroke);
   text-align: right;
 }
 
 .remove-item {
   background: none;
   border: none;
-  color: #FF3B30;
+  color: var(--color-error);
   cursor: pointer;
-  padding: 8px;
-  border-radius: 6px;
+  padding: var(--spacing-2);
+  border-radius: var(--radius-sm);
   transition: background-color 0.2s ease;
   display: flex;
   align-items: center;
@@ -70,13 +70,13 @@
   border: 1px dashed #22C55E;
   color: #22C55E;
   cursor: pointer;
-  padding: 12px;
-  border-radius: 8px;
+  padding: var(--spacing-3);
+  border-radius: var(--spacing-2);
   transition: all 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-size: 15px;
   font-weight: 500;
   font-family: system-ui, -apple-system, sans-serif;
@@ -91,63 +91,63 @@
 .summary-grid {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
 .summary-label {
   font-size: 15px;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .summary-value {
   font-size: 15px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
   text-align: right;
 }
 
 .summary-total {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 700;
-  color: #0A0A0A;
-  padding-top: 12px;
-  border-top: 2px solid #E5E5EA;
+  color: var(--color-text-high);
+  padding-top: var(--spacing-3);
+  border-top: 2px solid var(--color-stroke);
 }
 
 .customer-info {
-  margin-top: 12px;
-  padding: 12px;
-  background-color: #FFFFFF;
-  border-radius: 6px;
+  margin-top: var(--spacing-3);
+  padding: var(--spacing-3);
+  background-color: var(--color-surface-01);
+  border-radius: var(--radius-sm);
   font-size: 13px;
-  color: #545454;
+  color: var(--color-text-medium);
 }
 
 .items-readonly {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .readonly-item {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .item-separator {
   border: none;
-  border-top: 1px solid #E5E5EA;
-  margin: 16px 0;
+  border-top: 1px solid var(--color-stroke);
+  margin: var(--spacing-4) 0;
 }
 
 @media (max-width: 768px) {
   .item-row {
     flex-direction: column;
-    gap: 12px;
+    gap: var(--spacing-3);
   }
   
   .item-quantity,
@@ -158,7 +158,7 @@
   
   .summary-grid {
     grid-template-columns: 1fr;
-    gap: 8px;
+    gap: var(--spacing-2);
   }
   
   .summary-value {

--- a/src/components/Purchase/PurchaseList.module.css
+++ b/src/components/Purchase/PurchaseList.module.css
@@ -3,12 +3,12 @@
 .avatar {
   width: 48px;
   height: 48px;
-  background-color: #1476FF;
+  background-color: var(--color-primary);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #FFFFFF;
+  color: var(--color-surface-01);
   font-weight: 600;
   font-size: 18px;
   font-family: system-ui, -apple-system, sans-serif;
@@ -19,14 +19,14 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   min-width: 0;
 }
 
 .name {
   font-size: 17px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
   margin: 0;
   white-space: nowrap;
@@ -42,7 +42,7 @@
 
 .contact-detail {
   font-size: 13px;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
@@ -54,15 +54,15 @@
 
 .empty-state {
   text-align: center;
-  padding: 48px 24px;
-  color: #8E8E93;
+  padding: 48px var(--spacing-6);
+  color: var(--color-text-low);
 }
 
 .empty-state h3 {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 600;
-  color: #545454;
-  margin: 0 0 8px 0;
+  color: var(--color-text-medium);
+  margin: 0 0 var(--spacing-2) 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
@@ -75,17 +75,17 @@
 .list-container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 @media (max-width: 640px) {
   .avatar {
     width: 40px;
     height: 40px;
-    font-size: 16px;
+    font-size: var(--spacing-4);
   }
   
   .contact-detail {
-    font-size: 12px;
+    font-size: var(--spacing-3);
   }
 }

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -8,51 +8,51 @@
 .search-input {
   width: 100%;
   height: 44px;
-  padding: 0 16px 0 44px;
+  padding: 0 var(--spacing-4) 0 44px;
   font-size: 15px;
   font-weight: 400;
   line-height: 22px;
   font-family: system-ui, -apple-system, sans-serif;
-  background-color: #F6F7F9;
-  border: 1px solid #E5E5EA;
+  background-color: var(--color-surface-02);
+  border: 1px solid var(--color-stroke);
   border-radius: 10px;
   outline: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .search-input:focus {
-  border-color: #1476FF;
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(20, 118, 255, 0.1);
 }
 
 .search-input::placeholder {
-  color: #8E8E93;
+  color: var(--color-text-low);
 }
 
 .search-icon {
   position: absolute;
-  left: 12px;
+  left: var(--spacing-3);
   top: 50%;
   transform: translateY(-50%);
-  color: #8E8E93;
+  color: var(--color-text-low);
   pointer-events: none;
 }
 
 .clear-button {
   position: absolute;
-  right: 8px;
+  right: var(--spacing-2);
   top: 50%;
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: #8E8E93;
+  color: var(--color-text-low);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--spacing-1);
+  border-radius: var(--spacing-1);
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .clear-button:hover {
   background-color: rgba(0, 0, 0, 0.05);
-  color: #545454;
+  color: var(--color-text-medium);
 }

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -5,8 +5,8 @@
   left: 0;
   height: 100vh;
   width: 280px;
-  background-color: #FFFFFF;
-  border-right: 1px solid #E5E5EA;
+  background-color: var(--color-surface-01);
+  border-right: 1px solid var(--color-stroke);
   display: flex;
   flex-direction: column;
   z-index: 100;
@@ -18,23 +18,23 @@
 }
 
 .header {
-  padding: 24px;
-  border-bottom: 1px solid #E5E5EA;
+  padding: var(--spacing-6);
+  border-bottom: 1px solid var(--color-stroke);
 }
 
 .logo {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
 }
 
 .logo-icon {
   width: 32px;
   height: 32px;
-  background-color: #1476FF;
-  color: #FFFFFF;
-  border-radius: 8px;
+  background-color: var(--color-primary);
+  color: var(--color-surface-01);
+  border-radius: var(--spacing-2);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -45,44 +45,44 @@
 .app-title {
   font-size: 17px;
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   margin: 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .app-subtitle {
   font-size: 13px;
-  color: #8E8E93;
+  color: var(--color-text-low);
   margin: 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .navigation {
   flex: 1;
-  padding: 16px 0;
+  padding: var(--spacing-4) 0;
 }
 
 .nav-section {
-  margin-bottom: 24px;
+  margin-bottom: var(--spacing-6);
 }
 
 .nav-title {
   font-size: 13px;
   font-weight: 600;
-  color: #8E8E93;
+  color: var(--color-text-low);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin: 0 0 12px 0;
-  padding: 0 24px;
+  margin: 0 0 var(--spacing-3) 0;
+  padding: 0 var(--spacing-6);
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .nav-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 24px;
-  color: #545454;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-6);
+  color: var(--color-text-medium);
   text-decoration: none;
   font-size: 15px;
   font-weight: 400;
@@ -96,37 +96,37 @@
 }
 
 .nav-item:hover {
-  background-color: #F6F7F9;
-  color: #0A0A0A;
+  background-color: var(--color-surface-02);
+  color: var(--color-text-high);
 }
 
 .nav-item--active {
   background-color: #F0F9FF;
-  color: #1476FF;
+  color: var(--color-primary);
   font-weight: 500;
-  border-right: 3px solid #1476FF;
+  border-right: 3px solid var(--color-primary);
 }
 
 .nav-item--active:hover {
   background-color: #F0F9FF;
-  color: #1476FF;
+  color: var(--color-primary);
 }
 
 .nav-badge {
   margin-left: auto;
-  background-color: #E5E5EA;
-  color: #8E8E93;
+  background-color: var(--color-stroke);
+  color: var(--color-text-low);
   font-size: 11px;
   font-weight: 600;
   padding: 2px 6px;
-  border-radius: 8px;
-  min-width: 16px;
+  border-radius: var(--spacing-2);
+  min-width: var(--spacing-4);
   text-align: center;
 }
 
 .nav-item--active .nav-badge {
-  background-color: #1476FF;
-  color: #FFFFFF;
+  background-color: var(--color-primary);
+  color: var(--color-surface-01);
 }
 
 .nav-item--disabled {
@@ -136,25 +136,25 @@
 
 .toggle-button {
   position: fixed;
-  top: 24px;
-  left: 24px;
+  top: var(--spacing-6);
+  left: var(--spacing-6);
   width: 40px;
   height: 40px;
-  background-color: #FFFFFF;
-  border: 1px solid #E5E5EA;
-  border-radius: 8px;
+  background-color: var(--color-surface-01);
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--spacing-2);
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.06);
   cursor: pointer;
   display: none;
   align-items: center;
   justify-content: center;
-  color: #545454;
+  color: var(--color-text-medium);
   z-index: 101;
   transition: all 0.2s ease;
 }
 
 .toggle-button:hover {
-  background-color: #F6F7F9;
+  background-color: var(--color-surface-02);
   transform: scale(1.05);
 }
 

--- a/src/components/ui/Avatar.module.css
+++ b/src/components/ui/Avatar.module.css
@@ -16,7 +16,7 @@
 .avatar--small {
   width: 32px;
   height: 32px;
-  font-size: 12px;
+  font-size: var(--spacing-3);
 }
 
 .avatar--medium {
@@ -37,11 +37,11 @@
 }
 
 .avatar--product {
-  background-color: #34C759; /* Verde para productos */
+  background-color: var(--color-success); /* Verde para productos */
 }
 
 .avatar--purchase {
-  background-color: #FF9500; /* Naranja para compras */
+  background-color: var(--color-warning); /* Naranja para compras */
 }
 
 /* Estados hover y focus para interactividad */
@@ -55,7 +55,7 @@
   .avatar--large {
     width: 48px;
     height: 48px;
-    font-size: 16px;
+    font-size: var(--spacing-4);
   }
   
   .avatar--medium {

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -1,6 +1,6 @@
 /* Estilos para el componente Button */
 .button {
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   outline: none;
   font-family: system-ui, -apple-system, sans-serif;
@@ -8,7 +8,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   border: none;
 }
 
@@ -18,44 +18,44 @@
 
 /* Variantes */
 .button--primary {
-  background-color: #1476FF;
-  color: #FFFFFF;
+  background-color: var(--color-primary);
+  color: var(--color-surface-01);
 }
 
 .button--primary:hover:not(:disabled) {
-  background-color: #0F64DB;
+  background-color: var(--color-primary-hover);
 }
 
 .button--primary:disabled {
-  background-color: #8E8E93;
+  background-color: var(--color-text-low);
 }
 
 .button--secondary {
-  background-color: #F6F7F9;
-  color: #0A0A0A;
-  border: 1px solid #E5E5EA;
+  background-color: var(--color-surface-02);
+  color: var(--color-text-high);
+  border: 1px solid var(--color-stroke);
 }
 
 .button--ghost {
   background-color: transparent;
-  color: #1476FF;
+  color: var(--color-primary);
 }
 
 /* Tamaños */
 .button--sm {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   font-size: 13px;
   font-weight: 400;
 }
 
 .button--md {
-  padding: 12px 20px;
+  padding: var(--spacing-3) var(--spacing-5);
   font-size: 17px;
   font-weight: 600;
 }
 
 .button--lg {
-  padding: 16px 24px;
-  font-size: 20px;
+  padding: var(--spacing-4) var(--spacing-6);
+  font-size: var(--spacing-5);
   font-weight: 600;
 }

--- a/src/components/ui/FormActions.module.css
+++ b/src/components/ui/FormActions.module.css
@@ -1,7 +1,7 @@
 /* Estilos para el pie del formulario y las acciones */
 .form-footer {
-  padding: 20px 0 0 0;
-  border-top: 1px solid #E5E5EA;
+  padding: var(--spacing-5) 0 0 0;
+  border-top: 1px solid var(--color-stroke);
   flex-shrink: 0;
   background-color: white;
 }
@@ -29,8 +29,8 @@
 }
 
 .delete-button {
-  color: #FF3B30 !important;
-  border-color: #FF3B30 !important;
+  color: var(--color-error) !important;
+  border-color: var(--color-error) !important;
 }
 
 .delete-button:hover {

--- a/src/components/ui/FormContainer.module.css
+++ b/src/components/ui/FormContainer.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   height: 100%;
   background: white;
-  border-radius: 20px;
+  border-radius: var(--spacing-5);
   overflow: hidden;
 }
 

--- a/src/components/ui/FormErrors.module.css
+++ b/src/components/ui/FormErrors.module.css
@@ -1,29 +1,29 @@
 /* Estilos para el componente de errores de formulario */
 .form-header {
   padding: 10px;
-  border-bottom: 1px solid #E5E5EA;
+  border-bottom: 1px solid var(--color-stroke);
   flex-shrink: 0;
   background-color: white;
 }
 
 .error-list {
   background-color: #FFE5E5;
-  border: 1px solid #FF3B30;
-  border-radius: 6px;
-  padding: 12px;
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-3);
 }
 
 .error-title {
   font-size: 13px;
   font-weight: 600;
-  color: #FF3B30;
-  margin: 0 0 8px 0;
+  color: var(--color-error);
+  margin: 0 0 var(--spacing-2) 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .error-item {
   font-size: 13px;
-  color: #FF3B30;
-  margin: 4px 0;
+  color: var(--color-error);
+  margin: var(--spacing-1) 0;
   font-family: system-ui, -apple-system, sans-serif;
 }

--- a/src/components/ui/FormRow.module.css
+++ b/src/components/ui/FormRow.module.css
@@ -1,7 +1,7 @@
 /* Estilos para el componente FormRow */
 .form-row {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .form-row > * {
@@ -11,6 +11,6 @@
 @media (max-width: 640px) {
   .form-row {
     flex-direction: column;
-    gap: 20px;
+    gap: var(--spacing-5);
   }
 }

--- a/src/components/ui/FormSection.module.css
+++ b/src/components/ui/FormSection.module.css
@@ -1,6 +1,6 @@
 .section {
-  border: 1px solid #E5E5EA;
-  border-radius: 12px;
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--spacing-3);
   padding: 10px;
   background-color: #FAFAFA;
 }
@@ -8,12 +8,12 @@
 .section-title {
   font-size: 17px;
   font-weight: 600;
-  color: #0A0A0A;
-  margin: 0 0 16px;
+  color: var(--color-text-high);
+  margin: 0 0 var(--spacing-4);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .section--customer {

--- a/src/components/ui/InputField.module.css
+++ b/src/components/ui/InputField.module.css
@@ -2,14 +2,14 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   width: 100%;
 }
 
 .label {
   font-size: 13px;
   font-weight: 400;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
 }
 
@@ -22,14 +22,14 @@
 .input {
   width: 100%;
   height: 44px;
-  padding: 0 16px;
+  padding: 0 var(--spacing-4);
   font-size: 15px;
   font-weight: 400;
   line-height: 22px;
   font-family: system-ui, -apple-system, sans-serif;
-  background-color: #F6F7F9;
-  border: 1px solid #E5E5EA;
-  border-radius: 6px;
+  background-color: var(--color-surface-02);
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--radius-sm);
   outline: none;
   transition: border-color 0.2s ease;
 }
@@ -39,35 +39,35 @@
 }
 
 .input--error {
-  border-color: #FF3B30;
+  border-color: var(--color-error);
 }
 
 .input:focus {
-  border-color: #1476FF;
+  border-color: var(--color-primary);
 }
 
 .input::placeholder {
-  color: #8E8E93;
+  color: var(--color-text-low);
 }
 
 .icon {
   position: absolute;
-  left: 12px;
-  color: #8E8E93;
+  left: var(--spacing-3);
+  color: var(--color-text-low);
   pointer-events: none;
 }
 
 .error {
   font-size: 13px;
-  color: #FF3B30;
+  color: var(--color-error);
   font-family: system-ui, -apple-system, sans-serif;
 }
 
 .input--readonly {
   /* background-color: transparent; */
   border: none;
-  padding: 8px;
-  color: #0A0A0A;
+  padding: var(--spacing-2);
+  color: var(--color-text-high);
   font-weight: 500;
   cursor: default;
 }
@@ -83,6 +83,6 @@
 }
 
 .icon--readonly {
-  color: #1476FF;
+  color: var(--color-primary);
   left: 0;
 }

--- a/src/components/ui/ListCard.module.css
+++ b/src/components/ui/ListCard.module.css
@@ -1,16 +1,16 @@
 .card {
-  background-color: #FFFFFF;
-  border-radius: 20px;
+  background-color: var(--color-surface-01);
+  border-radius: var(--spacing-5);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
-  padding: 16px;
+  padding: var(--spacing-4);
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 var(--spacing-1) var(--spacing-3) rgba(0, 0, 0, 0.1);
 }

--- a/src/components/ui/ListContainer.module.css
+++ b/src/components/ui/ListContainer.module.css
@@ -14,23 +14,23 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 60px 20px;
-  color: #8E8E93;
+  padding: 60px var(--spacing-5);
+  color: var(--color-text-low);
   min-height: 200px;
 }
 
 .empty-state h3 {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 600;
-  margin: 0 0 8px;
+  margin: 0 0 var(--spacing-2);
   color: #1C1C1E;
 }
 
 .empty-state p {
-  font-size: 16px;
+  font-size: var(--spacing-4);
   font-weight: 400;
   margin: 0;
-  color: #8E8E93;
+  color: var(--color-text-low);
 }
 
 /* Responsive */
@@ -40,7 +40,7 @@
   }
   
   .empty-state {
-    padding: 40px 20px;
+    padding: 40px var(--spacing-5);
     min-height: 160px;
   }
   

--- a/src/components/ui/ManagementHeader.module.css
+++ b/src/components/ui/ManagementHeader.module.css
@@ -5,9 +5,9 @@
   margin-bottom: 2rem;
   padding: 10px;
   background: #ffffff;
-  border-radius: 20px;
+  border-radius: var(--spacing-5);
   border: 1px solid var(--color-border);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px var(--spacing-2) rgba(0, 0, 0, 0.1);
 }
 
 .title-section {
@@ -40,7 +40,7 @@
   background: var(--color-primary);
   color: white;
   padding: 0.25rem 0.75rem;
-  border-radius: 20px;
+  border-radius: var(--spacing-5);
   font-size: 0.875rem;
   font-weight: 600;
   min-width: 2rem;

--- a/src/components/ui/Modal.module.css
+++ b/src/components/ui/Modal.module.css
@@ -10,13 +10,13 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .modal {
-  background-color: #FFFFFF;
-  border-radius: 20px;
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-surface-01);
+  border-radius: var(--spacing-5);
+  box-shadow: 0px var(--spacing-1) var(--spacing-3) rgba(0, 0, 0, 0.08);
   width: 100%;
   max-width: 500px;
   max-height: 90vh;
@@ -32,7 +32,7 @@
 @keyframes modalSlideIn {
   from {
     opacity: 0;
-    transform: scale(0.9) translateY(-20px);
+    transform: scale(0.9) translateY(-var(--spacing-5));
   }
   to {
     opacity: 1;
@@ -45,14 +45,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px;
-  border-bottom: 1px solid #E5E5EA;
+  border-bottom: 1px solid var(--color-stroke);
   flex-shrink: 0;
 }
 
 .title {
-  font-size: 20px;
+  font-size: var(--spacing-5);
   font-weight: 600;
-  color: #0A0A0A;
+  color: var(--color-text-high);
   font-family: system-ui, -apple-system, sans-serif;
   margin: 0 0 0 10px;
 }
@@ -60,15 +60,15 @@
 .close-button {
   background: none;
   border: none;
-  color: #8E8E93;
+  color: var(--color-text-low);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 6px;
+  padding: var(--spacing-1);
+  border-radius: var(--radius-sm);
   transition: background-color 0.2s ease;
 }
 
 .close-button:hover {
-  background-color: #F6F7F9;
+  background-color: var(--color-surface-02);
 }
 
 .content {
@@ -80,9 +80,9 @@
 
 .footer {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   justify-content: flex-end;
   padding: 15px 10px 10px;
-  border-top: 1px solid #E5E5EA;
+  border-top: 1px solid var(--color-stroke);
   flex-shrink: 0;
 }

--- a/src/components/ui/SelectField.module.css
+++ b/src/components/ui/SelectField.module.css
@@ -1,23 +1,23 @@
 .select-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   flex: 1;
 }
 
 .label {
   font-size: 13px;
   font-weight: 400;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
-  gap: 8px;
+  margin-bottom: var(--spacing-1);
+  gap: var(--spacing-2);
 }
 
 .required {
-  color: #FF3B30;
+  color: var(--color-error);
 }
 
 .select-container {
@@ -27,48 +27,48 @@
 .select {
   width: 100%;
   height: 44px;
-  padding: 0 16px;
+  padding: 0 var(--spacing-4);
   font-size: 15px;
   font-weight: 400;
   line-height: 22px;
   font-family: system-ui, -apple-system, sans-serif;
-  background-color: #F6F7F9;
-  border: 1px solid #E5E5EA;
-  border-radius: 6px;
+  background-color: var(--color-surface-02);
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--radius-sm);
   outline: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
   appearance: none;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
-  background-position: right 12px center;
+  background-position: right var(--spacing-3) center;
   background-repeat: no-repeat;
-  background-size: 16px;
+  background-size: var(--spacing-4);
   padding-right: 40px;
 }
 
 .select:focus {
-  border-color: #1476FF;
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(20, 118, 255, 0.1);
 }
 
 .select:disabled {
   background-color: #F0F0F0;
-  color: #8E8E93;
+  color: var(--color-text-low);
   cursor: not-allowed;
 }
 
 .select--error {
-  border-color: #FF3B30;
+  border-color: var(--color-error);
 }
 
 .select--error:focus {
-  border-color: #FF3B30;
+  border-color: var(--color-error);
   box-shadow: 0 0 0 3px rgba(255, 59, 48, 0.1);
 }
 
 .error {
-  font-size: 12px;
-  color: #FF3B30;
-  margin-top: 4px;
+  font-size: var(--spacing-3);
+  color: var(--color-error);
+  margin-top: var(--spacing-1);
   font-family: system-ui, -apple-system, sans-serif;
 }

--- a/src/components/ui/TextAreaField.module.css
+++ b/src/components/ui/TextAreaField.module.css
@@ -2,18 +2,18 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   width: 100%;
 }
 
 .label {
   font-size: 13px;
   font-weight: 400;
-  color: #545454;
+  color: var(--color-text-medium);
   font-family: system-ui, -apple-system, sans-serif;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .textarea-container {
@@ -25,14 +25,14 @@
 .textarea {
   width: 100%;
   min-height: 80px;
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   font-size: 15px;
   font-weight: 400;
   line-height: 22px;
   font-family: system-ui, -apple-system, sans-serif;
-  background-color: #F6F7F9;
-  border: 1px solid #E5E5EA;
-  border-radius: 6px;
+  background-color: var(--color-surface-02);
+  border: 1px solid var(--color-stroke);
+  border-radius: var(--radius-sm);
   outline: none;
   transition: border-color 0.2s ease;
   resize: vertical;
@@ -43,39 +43,39 @@
 }
 
 .textarea--error {
-  border-color: #FF3B30;
+  border-color: var(--color-error);
 }
 
 .textarea:focus {
-  border-color: #1476FF;
+  border-color: var(--color-primary);
 }
 
 .textarea::placeholder {
-  color: #8E8E93;
+  color: var(--color-text-low);
 }
 
 .textarea--readonly {
-  background-color: #F6F7F9;
+  background-color: var(--color-surface-02);
   cursor: default;
-  border-color: #E5E5EA;
+  border-color: var(--color-stroke);
 }
 
 .icon {
   position: absolute;
   left: 14px;
   top: 14px;
-  color: #8E8E93;
+  color: var(--color-text-low);
   pointer-events: none;
   z-index: 1;
 }
 
 .icon--readonly {
-  color: #8E8E93;
+  color: var(--color-text-low);
 }
 
 .error {
-  font-size: 12px;
-  color: #FF3B30;
+  font-size: var(--spacing-3);
+  color: var(--color-error);
   font-family: system-ui, -apple-system, sans-serif;
   margin-top: 2px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import "./styles/variables.css";
 /* Reset y estilos globales */
 * {
   box-sizing: border-box;
@@ -6,12 +7,11 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: var(--font-family-base);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #F6F7F9;
-  color: #0A0A0A;
+  background-color: var(--color-surface-02);
+  color: var(--color-text-high);
 }
 
 #root {
@@ -19,15 +19,15 @@ body {
 }
 
 button {
-  font-family: inherit;
+  font-family: var(--font-family-base);
 }
 
 input, textarea {
-  font-family: inherit;
+  font-family: var(--font-family-base);
 }
 
 a {
-  color: #1476FF;
+  color: var(--color-primary);
   text-decoration: none;
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,53 @@
+:root {
+  /* Color tokens */
+  --color-primary: #1476FF;
+  --color-primary-hover: #0F64DB;
+  --color-error: #FF3B30;
+  --color-warning: #FF9500;
+  --color-success: #34C759;
+  --color-info: #5AC8FA;
+  --color-text-high: #0A0A0A;
+  --color-text-medium: #545454;
+  --color-text-low: #8E8E93;
+  --color-surface-01: #FFFFFF;
+  --color-surface-02: #F6F7F9;
+  --color-stroke: #E5E5EA;
+  --color-overlay: rgba(0,0,0,0.25);
+
+  /* Typography tokens */
+  --font-family-base: system-ui, -apple-system, sans-serif;
+  --font-size-h1: 24px;
+  --font-weight-h1: 700;
+  --line-height-h1: 32px;
+  --font-size-h2: 20px;
+  --font-weight-h2: 600;
+  --line-height-h2: 28px;
+  --font-size-h3: 17px;
+  --font-weight-h3: 600;
+  --line-height-h3: 24px;
+  --font-size-body: 15px;
+  --font-weight-body: 400;
+  --line-height-body: 22px;
+  --font-size-caption: 13px;
+  --font-weight-caption: 400;
+  --line-height-caption: 18px;
+
+  /* Spacing tokens (4px grid) */
+  --spacing-0: 0px;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+
+  /* Radius tokens */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-pill: 999px;
+
+  /* Shadow tokens */
+  --shadow-card: 0px 2px 6px rgba(0,0,0,0.06);
+  --shadow-elevated: 0px 4px 12px rgba(0,0,0,0.08);
+}


### PR DESCRIPTION
## Summary
- create `variables.css` with design tokens
- import tokens in `index.css`
- add migration, audit, and validation scripts
- update package.json scripts
- document token usage and copilot instructions
- automatically replace CSS hardcoded values

## Testing
- `npm run tokens:migrate`
- `npm run tokens:validate`
- `npm run tokens:audit`


------
https://chatgpt.com/codex/tasks/task_e_68795c4eecd08323af9fd34e6588b0e7